### PR TITLE
Replace fandom with minecraft.wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ Invite the bot at <a href="https://minecord.github.io">https://minecord.github.i
 
 <h1>Minecraft Reverse Engineering</h1>
 <p>
-  Every time Mojang releases a new snapshot, I peek inside the source code to figure out how new features work. I then share my findings with people in the technical Minecraft community and on the <a href="https://minecraft.fandom.com">official wiki</a>.
+  Every time Mojang releases a new snapshot, I peek inside the source code to figure out how new features work. I then share my findings with people in the technical Minecraft community and on the <a href="https://minecraft.wiki">wiki</a>.
 </p>
 <a href="/snapshots">Check out the findings here!</a>
 


### PR DESCRIPTION
- Replace fandom's minecraft wiki with the new wiki
- I also removed "official" - The wiki, neither `minecraft.wiki`, nor the fandom one is owned by Microsoft/Mojang; it's community maintained, so it's not considered "official"